### PR TITLE
Update brace annotations to handle CRLF files.

### DIFF
--- a/4coder_fleury_brace.cpp
+++ b/4coder_fleury_brace.cpp
@@ -157,6 +157,12 @@ Fleury4RenderCloseBraceAnnotation(Application_Links *app, Buffer_ID buffer, Text
             start_line.str += first_non_whitespace_offset;
             start_line.size -= first_non_whitespace_offset;
             
+            //NOTE(rjf): Special case to handle CRLF-newline files.
+            if(start_line.str[start_line.size - 1] == 13)
+            {
+                start_line.size -= 1;
+            }
+          
             u32 color = finalize_color(defcolor_comment, 0);
             color &= 0x00ffffff;
             color |= 0x80000000;


### PR DESCRIPTION
Previously, brace annotations show an extra garbage character in CRLF-newline files as the carriage-return is rendered with the other text. This removes the carriage-return at the end of the string.