### PR TITLE
Update 4coder_fleury_calc.cpp

### DIFF
--- a/4coder_fleury_calc.cpp
+++ b/4coder_fleury_calc.cpp
@@ -1183,19 +1183,21 @@ GetDataFromSourceCode(Application_Links *app, Buffer_ID buffer, Text_Layout_ID t
                 }
             }
             
-            int data_count = 0;
-            float *data = push_array_zero(arena, float, total_value_count);
-            for(DataChunk *chunk = first_data_chunk; chunk; chunk = chunk->next)
             {
-                for(int i = 0; i < ArrayCount(chunk->values); i += 1)
+                int data_count = 0;
+                float *data = push_array_zero(arena, float, total_value_count);
+                for(DataChunk *chunk = first_data_chunk; chunk; chunk = chunk->next)
                 {
-                    data[data_count] = chunk->values[i];
-                    data_count += 1;
+                    for(int i = 0; i < ArrayCount(chunk->values); i += 1)
+                    {
+                        data[data_count] = chunk->values[i];
+                        data_count += 1;
+                    }
                 }
+
+                *data_ptr = data;
+                *data_count_ptr = data_count;
             }
-            
-            *data_ptr = data;
-            *data_count_ptr = data_count;
             
             end_read_data:;
         }


### PR DESCRIPTION
On my linux machine I got:
```
4coder_fleury/4coder_fleury_calc.cpp: In function ‘void GetDataFromSourceCode(Application_Links*, Buffer_ID, Text_Layout_ID, i64, Arena*, float**, int*)’:
4coder_fleury/4coder_fleury_calc.cpp:1200:13: error: jump to label ‘end_read_data’
 1200 |             end_read_data:;
      |             ^~~~~~~~~~~~~
4coder_fleury/4coder_fleury_calc.cpp:1146:26: note:   from here
 1146 |                     goto end_read_data;
      |                          ^~~~~~~~~~~~~
4coder_fleury/4coder_fleury_calc.cpp:1187:20: note:   crosses initialization of ‘float* data’
 1187 |             float *data = push_array_zero(arena, float, total_value_count);
      |                    ^~~~
4coder_fleury/4coder_fleury_calc.cpp:1186:17: note:   crosses initialization of ‘int data_count’
 1186 |             int data_count = 0;
      |                 ^~~~~~~~~~
At global scope:
cc1plus: note: unrecognized command-line option ‘-Wno-logical-op-parentheses’ may have been intended to silence earlier diagnostics
```
So I put data_ptr and data_count_ptr definitions in the scope and it worked