### PR TITLE
Fix bugs in typedef parsing

### DIFF
--- a/4coder_fleury_index.cpp
+++ b/4coder_fleury_index.cpp
@@ -425,6 +425,32 @@ F4_Index_RequireTokenKind(F4_Index_ParseCtx *ctx, Token_Base_Kind kind, Token **
 }
 
 internal b32
+F4_Index_RequireTokenSubKind(F4_Index_ParseCtx *ctx, int sub_kind, Token **token_out, F4_Index_TokenSkipFlags flags)
+{
+    b32 result = 0;
+    Token *token = token_it_read(&ctx->it);
+    if(token)
+    {
+        if(token->sub_kind == sub_kind)
+        {
+            result = 1;
+            if(token_out)
+            {
+                *token_out = token;
+            }
+        }
+    }
+    else
+    {
+        ctx->done = 1;
+    }if(result)
+    {
+        F4_Index_ParseCtx_Inc(ctx, flags);
+    }
+    return result;
+}
+
+internal b32
 F4_Index_PeekToken(F4_Index_ParseCtx *ctx, String_Const_u8 string)
 {
     b32 result = 0;

--- a/4coder_fleury_index.cpp
+++ b/4coder_fleury_index.cpp
@@ -527,12 +527,12 @@ F4_Index_ParseComment(F4_Index_ParseCtx *ctx, Token *token)
     {
         if(string.str[i] == '@')
         {
-            F4_Index_MakeNote(ctx->app, ctx->file, 0, string_substring(string, Ii64(i, string.size-1)), F4_Index_NoteKind_CommentTag, 0, Ii64(token));
+            F4_Index_MakeNote(ctx->app, ctx->file, 0, string_substring(string, Ii64(i, string.size)), F4_Index_NoteKind_CommentTag, 0, Ii64(token));
             break;
         }
         else if(i+4 < string.size && string_match(S8Lit("TODO"), string_substring(string, Ii64(i, i + 4))))
         {
-            F4_Index_MakeNote(ctx->app, ctx->file, 0, string_substring(string, Ii64(i, string.size-1)), F4_Index_NoteKind_CommentToDo, 0, Ii64(token));
+            F4_Index_MakeNote(ctx->app, ctx->file, 0, string_substring(string, Ii64(i, string.size)), F4_Index_NoteKind_CommentToDo, 0, Ii64(token));
         }
     }
 }

--- a/4coder_fleury_index.h
+++ b/4coder_fleury_index.h
@@ -105,6 +105,7 @@ internal b32 F4_Index_ParseCtx_Inc(F4_Index_ParseCtx *ctx, F4_Index_TokenSkipFla
 #define F4_Index_ParseCtx_IncWs(ctx) F4_Index_ParseCtx_Inc(ctx, F4_Index_TokenSkipFlag_SkipWhitespace)
 internal b32 F4_Index_RequireToken(F4_Index_ParseCtx *ctx, String_Const_u8 string, F4_Index_TokenSkipFlags flags);
 internal b32 F4_Index_RequireTokenKind(F4_Index_ParseCtx *ctx, Token_Base_Kind kind, Token **token_out, F4_Index_TokenSkipFlags flags);
+internal b32 F4_Index_RequireTokenSubKind(F4_Index_ParseCtx *ctx, int sub_kind, Token **token_out, F4_Index_TokenSkipFlags flags);
 internal b32 F4_Index_PeekToken(F4_Index_ParseCtx *ctx, String_Const_u8 string);
 internal b32 F4_Index_PeekTokenKind(F4_Index_ParseCtx *ctx, Token_Base_Kind kind, Token **token_out);
 internal b32 F4_Index_PeekTokenSubKind(F4_Index_ParseCtx *ctx, int sub_kind, Token **token_out);

--- a/4coder_fleury_lang_cpp.cpp
+++ b/4coder_fleury_lang_cpp.cpp
@@ -37,7 +37,7 @@ F4_CPP_SkipParseBody(F4_Index_ParseCtx *ctx)
         }
         // NOTE(jack): Comments and macros can occur inside bodies that we would like to skip,
         //             and should still be indexed.
-        else if(F4_Index_RequireTokenKind(ctx, TokenBaseKind_Comment, &name, F4_Index_TokenSkipFlag_SkipWhitespace))
+        else if(F4_Index_PeekTokenKind(ctx, TokenBaseKind_Comment, &name))
         {
             F4_Index_ParseComment(ctx, name);
         }
@@ -56,7 +56,6 @@ F4_CPP_SkipParseBody(F4_Index_ParseCtx *ctx)
             nest -= 1;
             if(nest == 0)
             {
-                F4_Index_ParseCtx_Inc(ctx, F4_Index_TokenSkipFlag_SkipWhitespace);
                 break;
             }
         }

--- a/4coder_fleury_lang_cpp.cpp
+++ b/4coder_fleury_lang_cpp.cpp
@@ -259,16 +259,16 @@ internal F4_LANGUAGE_INDEXFILE(F4_CPP_IndexFile)
                 if(name)
                 {
                     F4_Index_Note* aliased_type_index_note = F4_Index_LookupNote(F4_Index_StringFromToken(ctx, aliased_type_token));
-                    F4_Index_NoteFlags flags = 0;
+                    F4_Index_NoteFlags note_flags = 0;
                     
                     if (aliased_type_index_note) {
-                        flags = aliased_type_index_note->flags;
+                        note_flags = aliased_type_index_note->flags;
                     }
 
                     F4_Index_MakeNote(ctx->app, ctx->file, 0,
                                       F4_Index_StringFromToken(ctx, name),
                                       F4_Index_NoteKind_Type,
-                                      flags, Ii64(name));
+                                      note_flags, Ii64(name));
                 }
             }
             

--- a/4coder_fleury_lang_cpp.cpp
+++ b/4coder_fleury_lang_cpp.cpp
@@ -165,6 +165,8 @@ internal F4_LANGUAGE_INDEXFILE(F4_CPP_IndexFile)
             //~ NOTE(rjf): Regular Typedef
             else
             {
+                Token *aliased_type_token = token_it_read(&ctx->it);
+
                 for(;token_it_inc_all(&ctx->it);)
                 {
                     Token *token = token_it_read(&ctx->it);
@@ -184,10 +186,17 @@ internal F4_LANGUAGE_INDEXFILE(F4_CPP_IndexFile)
                 F4_Index_SeekToken(ctx, S8Lit(";"));
                 if(name)
                 {
+                    F4_Index_Note* aliased_type_index_note = F4_Index_LookupNote(F4_Index_StringFromToken(ctx, aliased_type_token));
+                    F4_Index_NoteFlags flags = 0;
+                    
+                    if (aliased_type_index_note) {
+                        flags = aliased_type_index_note->flags;
+                    }
+
                     F4_Index_MakeNote(ctx->app, ctx->file, 0,
                                       F4_Index_StringFromToken(ctx, name),
                                       F4_Index_NoteKind_Type,
-                                      0, Ii64(name));
+                                      flags, Ii64(name));
                 }
             }
             

--- a/4coder_fleury_lang_cpp.cpp
+++ b/4coder_fleury_lang_cpp.cpp
@@ -8,7 +8,10 @@ F4_CPP_SkipParseBody(F4_Index_ParseCtx *ctx)
     for(;!ctx->done;)
     {
         Token *token = token_it_read(&ctx->it);
-        if(token->sub_kind == TokenCppKind_BraceOp)
+        if (!token) {
+            ctx->done = true;
+        }
+        else if(token->sub_kind == TokenCppKind_BraceOp)
         {
             nest += 1;
             body_found = 1;
@@ -18,11 +21,11 @@ F4_CPP_SkipParseBody(F4_Index_ParseCtx *ctx)
             nest -= 1;
             if(nest == 0)
             {
+                F4_Index_ParseCtx_Inc(ctx, F4_Index_TokenSkipFlag_SkipWhitespace);
                 break;
             }
         }
-        else
-        {
+        else if(body_found == 0) {
             break;
         }
         
@@ -83,6 +86,18 @@ internal F4_LANGUAGE_INDEXFILE(F4_CPP_IndexFile)
                                   F4_Index_StringFromToken(ctx, name),
                                   F4_Index_NoteKind_Type,
                                   note_flags, Ii64(name));
+                
+                // NOTE(jack): clear the prototype flag so that the typedef'd name
+                // is not flagged as a prototype
+                note_flags &= ~F4_Index_NoteFlag_Prototype;
+                if (F4_Index_RequireTokenKind(ctx, TokenBaseKind_Identifier, &name, flags))
+                {
+                    F4_Index_MakeNote(ctx->app, ctx->file, 0,
+                                      F4_Index_StringFromToken(ctx, name),
+                                      F4_Index_NoteKind_Type,
+                                      note_flags, Ii64(name));
+                }
+
             }
             
             //~ NOTE(rjf): Unions
@@ -100,6 +115,17 @@ internal F4_LANGUAGE_INDEXFILE(F4_CPP_IndexFile)
                                   F4_Index_StringFromToken(ctx, name),
                                   F4_Index_NoteKind_Type,
                                   note_flags, Ii64(name));
+                
+                // NOTE(jack): clear the prototype flag so that the typedef'd name
+                // is not flagged as a prototype
+                note_flags &= ~F4_Index_NoteFlag_Prototype;
+                if (F4_Index_RequireTokenKind(ctx, TokenBaseKind_Identifier, &name, flags))
+                {
+                    F4_Index_MakeNote(ctx->app, ctx->file, 0,
+                                      F4_Index_StringFromToken(ctx, name),
+                                      F4_Index_NoteKind_Type,
+                                      note_flags, Ii64(name));
+                }
             }
             
             //~ NOTE(rjf): Enums
@@ -154,6 +180,17 @@ internal F4_LANGUAGE_INDEXFILE(F4_CPP_IndexFile)
                 }
                 
                 if(name)
+                {
+                    F4_Index_MakeNote(ctx->app, ctx->file, 0,
+                                      F4_Index_StringFromToken(ctx, name),
+                                      F4_Index_NoteKind_Type,
+                                      note_flags, Ii64(name));
+                }
+                
+                // NOTE(jack): clear the prototype flag so that the typedef'd name
+                // is not flagged as a prototype
+                note_flags &= ~F4_Index_NoteFlag_Prototype;
+                if (F4_Index_RequireTokenKind(ctx, TokenBaseKind_Identifier, &name, flags))
                 {
                     F4_Index_MakeNote(ctx->app, ctx->file, 0,
                                       F4_Index_StringFromToken(ctx, name),


### PR DESCRIPTION
Corrected typedef'd type note flags;
Fixed parsing issue with inline union/struct definitions in the middle of a typedef;
Bug in F4_CPP_SkipParseBody where it would stop on the first token inside the scope;