### PR TITLE
added linux build script and some bug fixes for the linux build

### DIFF
--- a/4coder_fleury_index.cpp
+++ b/4coder_fleury_index.cpp
@@ -604,21 +604,21 @@ F4_Index_ParsePattern(F4_Index_ParseCtx *ctx, char *fmt, ...)
                 
                 case 'k':
                 {
-                    Token_Base_Kind kind = va_arg(args, Token_Base_Kind);
+                    Token_Base_Kind kind = (Token_Base_Kind)va_arg(args, int);
                     Token **output_token = va_arg(args, Token **);
                     parsed = parsed && F4_Index_RequireTokenKind(ctx, kind, output_token, flags);
                 }break;
                 
                 case 'b':
                 {
-                    i16 kind = va_arg(args, i16);
+                    i16 kind = (i16)va_arg(args, int);
                     Token **output_token = va_arg(args, Token **);
                     parsed = parsed && F4_Index_RequireTokenSubKind(ctx, kind, output_token, flags);
                 }break;
                 
                 case 'n':
                 {
-                    F4_Index_NoteKind kind = va_arg(args, F4_Index_NoteKind);
+                    F4_Index_NoteKind kind = (F4_Index_NoteKind)va_arg(args, int);
                     F4_Index_Note **output_note = va_arg(args, F4_Index_Note **);
                     Token *token = 0;
                     parsed = parsed && F4_Index_RequireTokenKind(ctx, TokenBaseKind_Identifier, &token, flags);

--- a/build_linux.sh
+++ b/build_linux.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+
+../bin/buildsuper_x64-linux.sh 4coder_fleury.cpp
+cp custom_4coder.so ../../custom_4coder.so


### PR DESCRIPTION
4coder_fleury_index.cpp contained va_args that didnt have the correct type in the second parameter, which led the application to crash anytime you would open a C/C++ file.
fixed by changing the second parameter to the promoted type and explicitly casting it back outside the function.

from Dots#0470